### PR TITLE
Add PlayerFeedsTransformer for Player Profile Data

### DIFF
--- a/src/sportsradar/transform/params/playerfeeds.py
+++ b/src/sportsradar/transform/params/playerfeeds.py
@@ -1,0 +1,6 @@
+from typing import List
+
+
+def remove_unwanted_feeds() -> List[str]:
+    feeds = ["_comment"]
+    return feeds

--- a/src/sportsradar/transform/playerfeeds.py
+++ b/src/sportsradar/transform/playerfeeds.py
@@ -1,0 +1,29 @@
+from src.sportsradar import logging_helpers
+from src.sportsradar.transform.classes import DataPreprocessor
+from src.sportsradar.transform.params.playerfeeds import remove_unwanted_feeds
+
+logger = logging_helpers.get_logger(__name__)
+
+
+class PlayerFeedsTransformer:
+    """
+    PlayerFeedsTransformer class is used to transform player profile data.
+
+    Args:
+        data (dict): A dictionary containing player profile data.
+
+    Methods:
+        transform_player_profile(): Transforms the player profile data by removing unwanted feeds.
+
+    Returns:
+        dict: The transformed player profile data.
+    """
+
+    def __init__(self, data: dict):
+        self.data = data
+
+    def transform_player_profile(self):
+        preprocessor = DataPreprocessor(
+            data=self.data, processor=remove_unwanted_feeds()
+        )
+        return preprocessor.data

--- a/test/unit/transform/playerfeeds.py
+++ b/test/unit/transform/playerfeeds.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+from dotenv import load_dotenv
+
+from src.sportsradar.transform.playerfeeds import PlayerFeedsTransformer
+
+load_dotenv("../../../.env")
+
+
+class TestConstants:
+    MONGODB_URL = f"{os.environ.get('MONGODB_URL')}"
+    MONGODB_DATABASE = f"{os.environ.get('MONGODB_DATABASE')}"
+
+
+class TestPlayerFeedsTransformer(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dummy_data = {
+            "home_team": "Team A",
+            "away_team": "Team B",
+            "_comment": "10-5",
+        }
+        self.gft = PlayerFeedsTransformer(self.dummy_data)
+
+    def test_transform_player_profile(self):
+        # Act
+        result = self.gft.transform_player_profile()
+
+        # Assert
+        self.assertIsInstance(result, dict)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[""], defaultTest="TestGameFeedsTransformer")


### PR DESCRIPTION
Introduces a new class `PlayerFeedsTransformer` for transforming player profile data by removing unwanted feeds. A new method `remove_unwanted_feeds` is added in `params/playerfeeds.py` which handles the elimination of specific feed types.
Also, instantiated a test case `TestPlayerFeedsTransformer` for testing the function `transform_player_profile`.

Files added/modified: 
1. `src/sportsradar/transform/params/playerfeeds.py` - Contains `remove_unwanted_feeds()` function.
2. `test/unit/transform/playerfeeds.py` - Test cases for the PlayerFeedsTransformer.
3. `src/sportsradar/transform/playerfeeds.py` - Contains PlayerFeedsTransformer class which uses `remove_unwanted_feeds()` to preprocess player feeds.